### PR TITLE
Improve navbar brand responsiveness

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10846,4 +10846,23 @@ html {
   background-repeat: no-repeat;
   min-height: 15rem;
 }
-.navbar-brand img { width: 275px; }
+.navbar {
+  flex-wrap: nowrap;
+}
+
+.navbar-brand {
+  flex: 1 1 auto;       /* allow shrinking */
+  text-align: center;
+  min-width: 0;
+}
+
+.navbar-brand img {
+  width: 100%;          /* scales down with container */
+  max-width: 275px;     /* keeps desktop size cap */
+  height: auto;
+}
+
+.navbar-toggler {
+  flex-shrink: 0;       /* toggle never shrinks */
+  margin-left: auto;
+}


### PR DESCRIPTION
## Summary
- keep navbar logo and toggler on one line using flexbox
- allow logo to shrink responsively down to mobile widths

## Testing
- `npx playwright install chromium` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c978a8388333a3c50ae6946c797e