### PR TITLE
Adjust navbar logo to scale with viewport

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10847,5 +10847,6 @@ html {
   min-height: 15rem;
 }
 .navbar-brand img {
-  width: 275px;
+  width: 70vw;
+  max-width: 275px;
 }


### PR DESCRIPTION
## Summary
- constrain navbar logo to 70% viewport width and max 275px

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cd889e2883338385705527964cda