### PR TITLE
Limit annuity author avatar to 50px

### DIFF
--- a/annuities.html
+++ b/annuities.html
@@ -38,7 +38,7 @@
                     <div class="row gx-5">
                         <div class="col-lg-3">
                             <div class="d-flex align-items-center mt-lg-5 mb-4">
-                                <img class="img-fluid rounded-circle" src="assets/stephen.jpg" alt="..." />
+                                <img class="rounded-circle author-avatar" src="assets/stephen.jpg" alt="Stephen M. duBarry" />
                                 <div class="ms-3">
                                     <div class="fw-bold">Stephen M. duBarry</div>
                                 </div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -10850,3 +10850,8 @@ html {
   width: 50vw;
   max-width: 275px;
 }
+
+.author-avatar {
+  width: 50px;
+  height: 50px;
+}


### PR DESCRIPTION
## Summary
- Remove Bootstrap `img-fluid` class from the annuity article's author image and apply a dedicated `author-avatar` class for consistent sizing.
- Define `author-avatar` CSS class to constrain avatar dimensions to 50×50 pixels, keeping the author name aligned beside it.

## Testing
- `npx --yes htmlhint annuities.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68c47670789883338966587797dd10a1