### PR TITLE
Use distinct avatar sizes for index and articles

### DIFF
--- a/annuities.html
+++ b/annuities.html
@@ -38,7 +38,7 @@
                     <div class="row gx-5">
                         <div class="col-lg-3">
                             <div class="d-flex align-items-center mt-lg-5 mb-4">
-                                <img class="rounded-circle author-avatar" src="assets/stephen.jpg" alt="Stephen M. duBarry" />
+                                <img class="rounded-circle author-avatar-lg" src="assets/stephen.jpg" alt="Stephen M. duBarry" />
                                 <div class="ms-3">
                                     <div class="fw-bold">Stephen M. duBarry, CFA</div>
                                 </div>

--- a/articles.html
+++ b/articles.html
@@ -123,7 +123,7 @@
                                 <div class="card-footer p-4 pt-0 bg-transparent border-top-0">
                                     <div class="d-flex align-items-end justify-content-between">
                                         <div class="d-flex align-items-center">
-                                            <img class="rounded-circle me-3" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
+                                            <img class="rounded-circle me-3 author-avatar" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
                                             <div class="small">
                                                 <div class="fw-bold">Kelly Rowan</div>
                                                 <div class="text-muted">March 12, 2023 &middot; 6 min read</div>
@@ -144,7 +144,7 @@
                                 <div class="card-footer p-4 pt-0 bg-transparent border-top-0">
                                     <div class="d-flex align-items-end justify-content-between">
                                         <div class="d-flex align-items-center">
-                                            <img class="rounded-circle me-3" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
+                                            <img class="rounded-circle me-3 author-avatar" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
                                             <div class="small">
                                                 <div class="fw-bold">Josiah Barclay</div>
                                                 <div class="text-muted">March 23, 2023 &middot; 4 min read</div>
@@ -165,7 +165,7 @@
                                 <div class="card-footer p-4 pt-0 bg-transparent border-top-0">
                                     <div class="d-flex align-items-end justify-content-between">
                                         <div class="d-flex align-items-center">
-                                            <img class="rounded-circle me-3" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
+                                            <img class="rounded-circle me-3 author-avatar" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
                                             <div class="small">
                                                 <div class="fw-bold">Evelyn Martinez</div>
                                                 <div class="text-muted">April 2, 2023 &middot; 10 min read</div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -10852,6 +10852,11 @@ html {
 }
 
 .author-avatar {
+  width: 40px;
+  height: 40px;
+}
+
+.author-avatar-lg {
   width: 50px;
   height: 50px;
 }

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
                                 <div class="card-footer p-4 pt-0 bg-transparent border-top-0">
                                     <div class="d-flex align-items-end justify-content-between">
                                         <div class="d-flex align-items-center">
-                                            <img class="rounded-circle me-3" src="assets/stephen.jpg" alt="..." />
+                                            <img class="rounded-circle me-3 author-avatar" src="assets/stephen.jpg" alt="..." />
                                             <div class="small">
                                                 <div class="fw-bold">Stephen M. duBarry, CFA</div>
                                                 <div class="text-muted">4 min read</div>
@@ -137,7 +137,7 @@
                                 <div class="card-footer p-4 pt-0 bg-transparent border-top-0">
                                     <div class="d-flex align-items-end justify-content-between">
                                         <div class="d-flex align-items-center">
-                                            <img class="rounded-circle me-3" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
+                                            <img class="rounded-circle me-3 author-avatar" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
                                             <div class="small">
                                                 <div class="fw-bold">Josiah Barclay</div>
                                                 <div class="text-muted">March 23, 2023 &middot; 4 min read</div>
@@ -158,7 +158,7 @@
                                 <div class="card-footer p-4 pt-0 bg-transparent border-top-0">
                                     <div class="d-flex align-items-end justify-content-between">
                                         <div class="d-flex align-items-center">
-                                            <img class="rounded-circle me-3" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
+                                            <img class="rounded-circle me-3 author-avatar" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
                                             <div class="small">
                                                 <div class="fw-bold">Evelyn Martinez</div>
                                                 <div class="text-muted">April 2, 2023 &middot; 10 min read</div>


### PR DESCRIPTION
## Summary
- use 40×40 `.author-avatar` on home and article list
- keep 50×50 `.author-avatar-lg` for article detail templates

## Testing
- `npm test` (command not found; attempted `apt-get update` but repositories not signed)
- `python - <<'PY' ...` (author-avatar-lg absent; author-avatar present)


------
https://chatgpt.com/codex/tasks/task_e_68c47bf8e168833398547d6c3ca06948