### PR TITLE
Add Calendly intro call button across navbars

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,8 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-</ul>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                        </ul>
                     </div>
                 </div>
             </nav>
@@ -114,5 +115,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
+        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/annuities.html
+++ b/annuities.html
@@ -27,7 +27,8 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-</ul>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                        </ul>
                     </div>
                 </div>
             </nav>
@@ -83,5 +84,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
+        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/articles.html
+++ b/articles.html
@@ -27,7 +27,8 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-</ul>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                        </ul>
                     </div>
                 </div>
             </nav>
@@ -196,5 +197,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
+        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/blog-post.html
+++ b/blog-post.html
@@ -27,7 +27,8 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-</ul>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                        </ul>
                     </div>
                 </div>
             </nav>
@@ -128,5 +129,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
+        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/bonds.html
+++ b/bonds.html
@@ -27,7 +27,8 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-</ul>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                        </ul>
                     </div>
                 </div>
             </nav>
@@ -86,5 +87,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
+        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -27,7 +27,8 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-</ul>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                        </ul>
                     </div>
                 </div>
             </nav>
@@ -137,6 +138,7 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
+        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
         <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *-->
         <!-- * *                               SB Forms JS                               * *-->
         <!-- * * Activate your form at https://startbootstrap.com/solution/contact-forms * *-->

--- a/faq.html
+++ b/faq.html
@@ -27,7 +27,8 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-</ul>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                        </ul>
                     </div>
                 </div>
             </nav>
@@ -152,5 +153,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
+        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,8 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-</ul>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                        </ul>
                     </div>
                 </div>
             </nav>
@@ -197,5 +198,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
+        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/performance.html
+++ b/performance.html
@@ -27,7 +27,8 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-</ul>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                        </ul>
                     </div>
                 </div>
             </nav>
@@ -81,5 +82,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
+        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- add a Book Intro Call button in every navbar that launches the Calendly intro meeting popup
- load the Calendly widget script on each page so the popup works consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c1d2601483338116baa5ced20cba