### PR TITLE
Fix Calendly intro call link

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary calendly-link" href="#" data-calendly-url="https://calendly.com/stewardshippartners/intro">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>
@@ -115,6 +115,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/annuities.html
+++ b/annuities.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary calendly-link" href="#" data-calendly-url="https://calendly.com/stewardshippartners/intro">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>
@@ -84,6 +84,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/articles.html
+++ b/articles.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary calendly-link" href="#" data-calendly-url="https://calendly.com/stewardshippartners/intro">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>
@@ -197,6 +197,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/blog-post.html
+++ b/blog-post.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary calendly-link" href="#" data-calendly-url="https://calendly.com/stewardshippartners/intro">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>
@@ -129,6 +129,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/bonds.html
+++ b/bonds.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary calendly-link" href="#" data-calendly-url="https://calendly.com/stewardshippartners/intro">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>
@@ -87,6 +87,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary calendly-link" href="#" data-calendly-url="https://calendly.com/stewardshippartners/intro">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>
@@ -138,7 +138,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
         <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *-->
         <!-- * *                               SB Forms JS                               * *-->
         <!-- * * Activate your form at https://startbootstrap.com/solution/contact-forms * *-->

--- a/faq.html
+++ b/faq.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary calendly-link" href="#" data-calendly-url="https://calendly.com/stewardshippartners/intro">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>
@@ -153,6 +153,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary calendly-link" href="#" data-calendly-url="https://calendly.com/stewardshippartners/intro">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>
@@ -198,6 +198,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -10,5 +10,74 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.current-year').forEach(el => {
         el.textContent = year;
     });
+
+    const calendlyLinks = Array.from(document.querySelectorAll('.calendly-link[data-calendly-url]'));
+    if (!calendlyLinks.length) {
+        return;
+    }
+
+    const CALENDLY_SCRIPT_ID = 'calendly-widget-script';
+    const CALENDLY_STYLES_ID = 'calendly-widget-styles';
+    let calendlyLoader;
+
+    const ensureCalendlyLoaded = () => {
+        if (window.Calendly) {
+            return Promise.resolve();
+        }
+
+        if (!calendlyLoader) {
+            calendlyLoader = new Promise((resolve, reject) => {
+                if (!document.getElementById(CALENDLY_STYLES_ID)) {
+                    const styles = document.createElement('link');
+                    styles.id = CALENDLY_STYLES_ID;
+                    styles.rel = 'stylesheet';
+                    styles.href = 'https://assets.calendly.com/assets/external/widget.css';
+                    document.head.appendChild(styles);
+                }
+
+                let script = document.getElementById(CALENDLY_SCRIPT_ID);
+                if (!script) {
+                    script = document.createElement('script');
+                    script.id = CALENDLY_SCRIPT_ID;
+                    script.src = 'https://assets.calendly.com/assets/external/widget.js';
+                    script.async = true;
+                    script.onload = () => resolve();
+                    script.onerror = () => {
+                        calendlyLoader = undefined;
+                        reject(new Error('Failed to load Calendly widget'));
+                    };
+                    document.head.appendChild(script);
+                } else {
+                    script.addEventListener('load', () => resolve());
+                    script.addEventListener('error', () => {
+                        calendlyLoader = undefined;
+                        reject(new Error('Failed to load Calendly widget'));
+                    });
+                }
+            });
+        }
+
+        return calendlyLoader;
+    };
+
+    calendlyLinks.forEach(link => {
+        link.addEventListener('click', event => {
+            event.preventDefault();
+            const url = link.getAttribute('data-calendly-url');
+            if (!url) {
+                return;
+            }
+
+            ensureCalendlyLoaded()
+                .then(() => {
+                    if (window.Calendly) {
+                        window.Calendly.initPopupWidget({ url });
+                    }
+                })
+                .catch(() => {
+                    // Fail silently if the script cannot be loaded.
+                });
+        });
+    });
 });
 

--- a/performance.html
+++ b/performance.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary calendly-link" href="#" data-calendly-url="https://calendly.com/stewardshippartners/intro">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>
@@ -82,6 +82,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- replace inline Calendly handler on the "Book Intro Call" button with a reusable data attribute across every page
- lazy-load the Calendly widget assets from scripts.js so the popup initializes reliably when the button is clicked

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68d6c4557f1c8333865cafc4af2ab746