### PR TITLE
Replace Calendly popup with direct link

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>

--- a/annuities.html
+++ b/annuities.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>

--- a/articles.html
+++ b/articles.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>

--- a/blog-post.html
+++ b/blog-post.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>

--- a/bonds.html
+++ b/bonds.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>

--- a/contact.html
+++ b/contact.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>

--- a/faq.html
+++ b/faq.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>

--- a/performance.html
+++ b/performance.html
@@ -27,7 +27,7 @@
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
                             <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
-                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="#" onclick="Calendly.initPopupWidget({url: 'https://calendly.com/stewardshippartners/intro'});return false;">Book Intro Call</a></li>
+                            <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- replace the navigation "Book Intro Call" button on every page with a direct Calendly link that opens in a new tab

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c7041f4483339804ab175fc22e05