### PR TITLE
Update hero buttons to new link destinations

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,8 +41,8 @@
                                 <h1 class="display-5 fw-bolder text-white mb-2">Invest with conviction</h1>
                                 <p class="lead fw-normal text-white-50 mb-4">Stewardship Partners can help you build generational wealth without compromising your biblical values.</p>
                                 <div class="d-grid gap-3 d-sm-flex justify-content-sm-center justify-content-xl-start">
-                                    <a class="btn btn-primary btn-lg px-4 me-sm-3" href="#features">Get Started</a>
-                                    <a class="btn btn-outline-light btn-lg px-4" href="#!">Learn More</a>
+                                    <a class="btn btn-primary btn-lg px-4 me-sm-3" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Get Started</a>
+                                    <a class="btn btn-outline-light btn-lg px-4" href="#features">Learn More</a>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- update the hero Get Started button to link to the Calendly intro call
- point the Learn More button to the features section anchor

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c9532df483338dd3a5e9b4ae890a