### PR TITLE
Add performance and CTA sections to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,24 @@
                     </div>
                 </div>
             </section>
+            <!-- Performance section-->
+            <section class="py-5 bg-light" id="performance">
+                <div class="container px-5 my-5">
+                    <div class="row gx-5 align-items-center">
+                        <div class="col-lg-5 mb-5 mb-lg-0">
+                            <h2 class="fw-bolder">Performance section</h2>
+                            <p class="lead fw-normal text-muted mb-0">
+                                Explore how our disciplined, values-aligned process has delivered results over the long term.
+                            </p>
+                        </div>
+                        <div class="col-lg-7">
+                            <div class="bg-white rounded-3 shadow-sm p-3">
+                                <div id="performance-chart" style="min-height: 340px"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
             <!-- Testimonial section-->
             <div class="py-5 bg-light">
                 <div class="container px-5 my-5">
@@ -94,6 +112,18 @@
                     </div>
                 </div>
             </div>
+            <!-- Call to action section-->
+            <section class="py-5" id="call-to-action">
+                <div class="container px-5 my-5">
+                    <div class="row gx-5 justify-content-center">
+                        <div class="col-lg-8 text-center">
+                            <h2 class="fw-bolder">Call to action section</h2>
+                            <p class="lead fw-normal text-muted mb-4">Ready to discover how biblical values and disciplined investing can work together for your family? Schedule a complimentary conversation with our team.</p>
+                            <a class="btn btn-primary btn-lg" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book an Intro Call</a>
+                        </div>
+                    </div>
+                </div>
+            </section>
             <!-- Blog preview section-->
             <section class="py-5">
                 <div class="container px-5 my-5">
@@ -182,6 +212,52 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
+        <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+        <script>
+            google.charts.load('current', { packages: ['corechart'] });
+            google.charts.setOnLoadCallback(drawPerformanceChart);
+
+            function drawPerformanceChart() {
+                const container = document.getElementById('performance-chart');
+                if (!container) {
+                    return;
+                }
+
+                const data = google.visualization.arrayToDataTable([
+                    ['Year', 'Stewardship Partners (net of fees)', 'S&P 500 Index'],
+                    ['2014', 0.098, 0.137],
+                    ['2015', 0.034, 0.014],
+                    ['2016', 0.116, 0.12],
+                    ['2017', 0.189, 0.218],
+                    ['2018', -0.039, -0.044],
+                    ['2019', 0.271, 0.315],
+                    ['2020', 0.158, 0.184],
+                    ['2021', 0.232, 0.287],
+                    ['2022', -0.115, -0.181],
+                    ['2023', 0.194, 0.263]
+                ]);
+
+                const options = {
+                    legend: { position: 'bottom' },
+                    colors: ['#1b5e20', '#0d47a1'],
+                    height: 320,
+                    chartArea: { left: 50, right: 20, top: 20, bottom: 60 },
+                    backgroundColor: 'transparent',
+                    hAxis: {
+                        textStyle: { fontSize: 12 }
+                    },
+                    vAxis: {
+                        format: '#%',
+                        textStyle: { fontSize: 12 }
+                    }
+                };
+
+                const chart = new google.visualization.LineChart(container);
+                chart.draw(data, options);
+            }
+
+            window.addEventListener('resize', drawPerformanceChart);
+        </script>
         <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- add a gray performance section beneath the features area and embed the Google Charts performance visualization
- introduce a white call-to-action section encouraging visitors to book an intro call
- load the Google Charts library and script necessary to render the performance graphic

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68d6d2bcb9d88333813a4bc8ca0ee0d6