### PR TITLE
Simplify articles page to featured posts

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -18,7 +18,7 @@
             <!-- Navigation-->
             <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
                 <div class="container px-5">
-                    <a class="navbar-brand" href="index.html"><img src="assets/logo.svg" /></a>
+                    <a class="navbar-brand" href="index.html"><img src="assets/logo.svg" alt="Stewardship Partners" /></a>
                     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
                     <div class="collapse navbar-collapse" id="navbarSupportedContent">
                         <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
@@ -26,107 +26,36 @@
                             <li class="nav-item"><a class="nav-link" href="about.html">About</a></li>
                             <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
                             <li class="nav-item"><a class="nav-link" href="faq.html">FAQ</a></li>
-                            <li class="nav-item"><a class="nav-link" href="articles.html">Articles</a></li>
+                            <li class="nav-item"><a class="nav-link active" aria-current="page" href="articles.html">Articles</a></li>
                             <li class="nav-item ms-lg-3 mt-3 mt-lg-0"><a class="btn btn-primary" href="https://calendly.com/stewardshippartners/intro" target="_blank" rel="noopener">Book Intro Call</a></li>
                         </ul>
                     </div>
                 </div>
             </nav>
-            <!-- Page Content-->
-            <section class="py-5">
-                <div class="container px-5">
-                    <h1 class="fw-bolder fs-5 mb-4">Company Blog</h1>
-                    <div class="card border-0 shadow rounded-3 overflow-hidden">
-                        <div class="card-body p-0">
-                            <div class="row gx-0">
-                                <div class="col-lg-6 col-xl-5 py-lg-5">
-                                    <div class="p-4 p-md-5">
-                                        <div class="badge bg-primary bg-gradient rounded-pill mb-2">News</div>
-                                        <div class="h2 fw-bolder">Article heading goes here</div>
-                                        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Similique delectus ab doloremque, qui doloribus ea officiis...</p>
-                                        <a class="stretched-link text-decoration-none" href="#!">
-                                            Read more
-                                            <i class="bi bi-arrow-right"></i>
-                                        </a>
-                                    </div>
-                                </div>
-                                <div class="col-lg-6 col-xl-7"><div class="bg-featured-blog" style="background-image: url('https://dummyimage.com/700x350/343a40/6c757d')"></div></div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </section>
+            <!-- Articles list-->
             <section class="py-5 bg-light">
-                <div class="container px-5">
-                    <div class="row gx-5">
-                        <div class="col-xl-8">
-                            <h2 class="fw-bolder fs-5 mb-4">News</h2>
-                            <!-- News item-->
-                            <div class="mb-4">
-                                <div class="small text-muted">May 12, 2023</div>
-                                <a class="link-dark" href="#!"><h3>Start Bootstrap releases Bootstrap 5 updates for templates and themes</h3></a>
-                            </div>
-                            <!-- News item-->
-                            <div class="mb-5">
-                                <div class="small text-muted">May 5, 2023</div>
-                                <a class="link-dark" href="#!"><h3>Bootstrap 5 has officially landed</h3></a>
-                            </div>
-                            <!-- News item-->
-                            <div class="mb-5">
-                                <div class="small text-muted">Apr 21, 2023</div>
-                                <a class="link-dark" href="#!"><h3>This is another news article headline, but this one is a little bit longer</h3></a>
-                            </div>
-                            <div class="text-end mb-5 mb-xl-0">
-                                <a class="text-decoration-none" href="#!">
-                                    More news
-                                    <i class="bi bi-arrow-right"></i>
-                                </a>
-                            </div>
-                        </div>
-                        <div class="col-xl-4">
-                            <div class="card border-0 h-100">
-                                <div class="card-body p-4">
-                                    <div class="d-flex h-100 align-items-center justify-content-center">
-                                        <div class="text-center">
-                                            <div class="h6 fw-bolder">Contact</div>
-                                            <p class="text-muted mb-4">
-                                                For press inquiries, email us at
-                                                <br />
-                                                <a href="#!">press@domain.com</a>
-                                            </p>
-                                            <div class="h6 fw-bolder">Follow us</div>
-                                            <a class="fs-5 px-2 link-dark" href="#!"><i class="bi-twitter"></i></a>
-                                            <a class="fs-5 px-2 link-dark" href="#!"><i class="bi-facebook"></i></a>
-                                            <a class="fs-5 px-2 link-dark" href="#!"><i class="bi-linkedin"></i></a>
-                                            <a class="fs-5 px-2 link-dark" href="#!"><i class="bi-youtube"></i></a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                <div class="container px-5 my-5">
+                    <div class="row gx-5 justify-content-center mb-5">
+                        <div class="col-lg-8 text-center">
+                            <h1 class="fw-bolder">Featured articles</h1>
+                            <p class="lead text-muted">Catch up on the same stories highlighted on our front page.</p>
                         </div>
                     </div>
-                </div>
-            </section>
-            <!-- Blog preview section-->
-            <section class="py-5">
-                <div class="container px-5">
-                    <h2 class="fw-bolder fs-5 mb-4">Featured Stories</h2>
                     <div class="row gx-5">
                         <div class="col-lg-4 mb-5">
                             <div class="card h-100 shadow border-0">
-                                <img class="card-img-top" src="https://dummyimage.com/600x350/ced4da/6c757d" alt="..." />
+                                <img class="card-img-top" src="assets/performance-6x3.5.jpg" alt="Chart trending upward" />
                                 <div class="card-body p-4">
-                                    <div class="badge bg-primary bg-gradient rounded-pill mb-2">News</div>
-                                    <a class="text-decoration-none link-dark stretched-link" href="#!"><div class="h5 card-title mb-3">Blog post title</div></a>
-                                    <p class="card-text mb-0">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+                                    <a class="text-decoration-none link-dark stretched-link" href="performance.html"><h2 class="h5 card-title mb-3">The perils of performance chasing</h2></a>
+                                    <p class="card-text mb-0">One of the most dangerous behavioral traps is performance chasing, in which investors select investments on the basis of past performance.</p>
                                 </div>
                                 <div class="card-footer p-4 pt-0 bg-transparent border-top-0">
                                     <div class="d-flex align-items-end justify-content-between">
                                         <div class="d-flex align-items-center">
-                                            <img class="rounded-circle me-3 author-avatar" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
+                                            <img class="rounded-circle me-3 author-avatar" src="assets/stephen.jpg" alt="Stephen M. duBarry" />
                                             <div class="small">
-                                                <div class="fw-bold">Kelly Rowan</div>
-                                                <div class="text-muted">March 12, 2023 &middot; 6 min read</div>
+                                                <div class="fw-bold">Stephen M. duBarry, CFA</div>
+                                                <div class="text-muted">3 min read</div>
                                             </div>
                                         </div>
                                     </div>
@@ -135,19 +64,18 @@
                         </div>
                         <div class="col-lg-4 mb-5">
                             <div class="card h-100 shadow border-0">
-                                <img class="card-img-top" src="https://dummyimage.com/600x350/adb5bd/495057" alt="..." />
+                                <img class="card-img-top" src="assets/bonds-6x3.5.jpg" alt="Close-up of bond certificates" />
                                 <div class="card-body p-4">
-                                    <div class="badge bg-primary bg-gradient rounded-pill mb-2">Media</div>
-                                    <a class="text-decoration-none link-dark stretched-link" href="#!"><div class="h5 card-title mb-3">Another blog post title</div></a>
-                                    <p class="card-text mb-0">This text is a bit longer to illustrate the adaptive height of each card. Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+                                    <a class="text-decoration-none link-dark stretched-link" href="bonds.html"><h2 class="h5 card-title mb-3">Should long-term investors hold bonds?</h2></a>
+                                    <p class="card-text mb-0">The conventional wisdom on Wall Street is that investors should have a significant allocation to bonds. But does this really help in the long run?</p>
                                 </div>
                                 <div class="card-footer p-4 pt-0 bg-transparent border-top-0">
                                     <div class="d-flex align-items-end justify-content-between">
                                         <div class="d-flex align-items-center">
-                                            <img class="rounded-circle me-3 author-avatar" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
+                                            <img class="rounded-circle me-3 author-avatar" src="assets/stephen.jpg" alt="Stephen M. duBarry" />
                                             <div class="small">
-                                                <div class="fw-bold">Josiah Barclay</div>
-                                                <div class="text-muted">March 23, 2023 &middot; 4 min read</div>
+                                                <div class="fw-bold">Stephen M. duBarry, CFA</div>
+                                                <div class="text-muted">5 min read</div>
                                             </div>
                                         </div>
                                     </div>
@@ -156,31 +84,24 @@
                         </div>
                         <div class="col-lg-4 mb-5">
                             <div class="card h-100 shadow border-0">
-                                <img class="card-img-top" src="https://dummyimage.com/600x350/6c757d/343a40" alt="..." />
+                                <img class="card-img-top" src="assets/annuities-6x3.5.jpg" alt="Stacked coins and pen" />
                                 <div class="card-body p-4">
-                                    <div class="badge bg-primary bg-gradient rounded-pill mb-2">News</div>
-                                    <a class="text-decoration-none link-dark stretched-link" href="#!"><div class="h5 card-title mb-3">The last blog post title is a little bit longer than the others</div></a>
-                                    <p class="card-text mb-0">Some more quick example text to build on the card title and make up the bulk of the card's content.</p>
+                                    <a class="text-decoration-none link-dark stretched-link" href="annuities.html"><h2 class="h5 card-title mb-3">Are annuities wise investments?</h2></a>
+                                    <p class="card-text mb-0">Insurance companies spend a lot of money to advertise annuities, but are they actually good investments for long-term investors?</p>
                                 </div>
                                 <div class="card-footer p-4 pt-0 bg-transparent border-top-0">
                                     <div class="d-flex align-items-end justify-content-between">
                                         <div class="d-flex align-items-center">
-                                            <img class="rounded-circle me-3 author-avatar" src="https://dummyimage.com/40x40/ced4da/6c757d" alt="..." />
+                                            <img class="rounded-circle me-3 author-avatar" src="assets/stephen.jpg" alt="Stephen M. duBarry" />
                                             <div class="small">
-                                                <div class="fw-bold">Evelyn Martinez</div>
-                                                <div class="text-muted">April 2, 2023 &middot; 10 min read</div>
+                                                <div class="fw-bold">Stephen M. duBarry, CFA</div>
+                                                <div class="text-muted">4 min read</div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="text-end mb-5 mb-xl-0">
-                        <a class="text-decoration-none" href="#!">
-                            More stories
-                            <i class="bi bi-arrow-right"></i>
-                        </a>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- replace the blog template in `articles.html` with a concise list of the three front-page features
- link each card to the matching article and reuse the imagery, author, and teaser copy from the homepage

## Testing
- Not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d6d47933e483338b6b2beb1c41748f