### PR TITLE
Update performance chart to Google bar chart with annotations

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
         <script src="js/scripts.js"></script>
         <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
         <script>
-            google.charts.load('current', { packages: ['corechart'] });
+            google.charts.load('current', { packages: ['corechart', 'bar'] });
             google.charts.setOnLoadCallback(drawPerformanceChart);
 
             function drawPerformanceChart() {
@@ -224,36 +224,54 @@
                 }
 
                 const data = google.visualization.arrayToDataTable([
-                    ['Year', 'Stewardship Partners (net of fees)', 'S&P 500 Index'],
-                    ['2014', 0.098, 0.137],
-                    ['2015', 0.034, 0.014],
-                    ['2016', 0.116, 0.12],
-                    ['2017', 0.189, 0.218],
-                    ['2018', -0.039, -0.044],
-                    ['2019', 0.271, 0.315],
-                    ['2020', 0.158, 0.184],
-                    ['2021', 0.232, 0.287],
-                    ['2022', -0.115, -0.181],
-                    ['2023', 0.194, 0.263]
+                    ['Time period', 'Global Multifactor (net)', 'Global equities benchmark'],
+                    ['Last 12 months', 0.2732, 0.163],
+                    ['2 years\nannualized', 0.2349, 0.1745],
+                    ['4 years\nannualized', 0.1315, 0.0775],
+                    ['5 years\nannualized', 0.2151, 0.1373],
+                    ['10 years\nannualized', 0.0908, 0.1001]
                 ]);
 
+                const view = new google.visualization.DataView(data);
+                view.setColumns([
+                    0,
+                    1,
+                    {
+                        calc: 'stringify',
+                        sourceColumn: 1,
+                        type: 'string',
+                        role: 'annotation'
+                    },
+                    2,
+                    {
+                        calc: 'stringify',
+                        sourceColumn: 2,
+                        type: 'string',
+                        role: 'annotation'
+                    }
+                ]);
+
+                const formatter = new google.visualization.NumberFormat({ pattern: '0.00%' });
+                formatter.format(data, 1);
+                formatter.format(data, 2);
+
                 const options = {
-                    legend: { position: 'bottom' },
-                    colors: ['#1b5e20', '#0d47a1'],
-                    height: 320,
-                    chartArea: { left: 50, right: 20, top: 20, bottom: 60 },
+                    colors: ['#1b408f', '#db1212'],
+                    legend: { position: 'top' },
                     backgroundColor: 'transparent',
+                    height: 400,
+                    chartArea: { height: '80%', width: '70%' },
                     hAxis: {
+                        format: '#%',
                         textStyle: { fontSize: 12 }
                     },
                     vAxis: {
-                        format: '#%',
                         textStyle: { fontSize: 12 }
                     }
                 };
 
-                const chart = new google.visualization.LineChart(container);
-                chart.draw(data, options);
+                const chart = new google.visualization.BarChart(container);
+                chart.draw(view, options);
             }
 
             window.addEventListener('resize', drawPerformanceChart);


### PR DESCRIPTION
## Summary
- replace the performance line chart with the requested Google bar chart dataset and styling
- add data view annotations and percent formatting to display bar values in-chart

## Testing
- python -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68d6dbadc2908333a6beef79414ff7d2