### PR TITLE
Improve performance chart responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,29 +233,38 @@
                 ]);
 
                 const view = new google.visualization.DataView(data);
-                view.setColumns([
-                    0,
-                    1,
-                    {
-                        calc: 'stringify',
-                        sourceColumn: 1,
-                        type: 'string',
-                        role: 'annotation'
-                    },
-                    2,
-                    {
-                        calc: 'stringify',
-                        sourceColumn: 2,
-                        type: 'string',
-                        role: 'annotation'
-                    }
-                ]);
+
+                const isMobile =
+                    container.offsetWidth <= 575 ||
+                    window.matchMedia('(max-width: 575.98px)').matches;
+
+                if (isMobile) {
+                    view.setColumns([0, 1, 2]);
+                } else {
+                    view.setColumns([
+                        0,
+                        1,
+                        {
+                            calc: 'stringify',
+                            sourceColumn: 1,
+                            type: 'string',
+                            role: 'annotation'
+                        },
+                        2,
+                        {
+                            calc: 'stringify',
+                            sourceColumn: 2,
+                            type: 'string',
+                            role: 'annotation'
+                        }
+                    ]);
+                }
 
                 const formatter = new google.visualization.NumberFormat({ pattern: '0.00%' });
                 formatter.format(data, 1);
                 formatter.format(data, 2);
 
-                const options = {
+                const baseOptions = {
                     colors: ['#1b408f', '#db1212'],
                     legend: { position: 'top' },
                     backgroundColor: 'transparent',
@@ -271,7 +280,18 @@
                 };
 
                 const chart = new google.visualization.BarChart(container);
-                chart.draw(view, options);
+                if (isMobile) {
+                    baseOptions.legend.position = 'bottom';
+                    baseOptions.chartArea = {
+                        height: '75%',
+                        width: '100%',
+                        left: 110,
+                        right: 16
+                    };
+                    baseOptions.vAxis.textStyle = { fontSize: 10 };
+                }
+
+                chart.draw(view, baseOptions);
             }
 
             window.addEventListener('resize', drawPerformanceChart);


### PR DESCRIPTION
## Summary
- make the performance chart responsive by detecting narrow layouts
- adjust legend, chart area, and axis styling for mobile screens
- hide annotations on mobile to reduce clutter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e05c9dc883339d6eb92c999cca50