### PR TITLE
Remove Calendly widget script from HTML pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -115,6 +115,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/annuities.html
+++ b/annuities.html
@@ -84,6 +84,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/articles.html
+++ b/articles.html
@@ -118,6 +118,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/blog-post.html
+++ b/blog-post.html
@@ -129,6 +129,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/bonds.html
+++ b/bonds.html
@@ -87,6 +87,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -138,7 +138,6 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
         <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *-->
         <!-- * *                               SB Forms JS                               * *-->
         <!-- * * Activate your form at https://startbootstrap.com/solution/contact-forms * *-->

--- a/faq.html
+++ b/faq.html
@@ -153,6 +153,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -296,6 +296,5 @@
 
             window.addEventListener('resize', drawPerformanceChart);
         </script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>

--- a/performance.html
+++ b/performance.html
@@ -82,6 +82,5 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Core theme JS-->
         <script src="js/scripts.js"></script>
-        <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- remove the external Calendly widget script from all HTML pages so the widget is no longer loaded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e221c7c88333ad0c31e65d4fc0b0