### PR TITLE
Adjust information table width to content

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10868,7 +10868,7 @@ html {
 
 .information-table {
   border-collapse: collapse;
-  width: 100%;
+  width: auto;
   font-size: 12pt;
 }
 


### PR DESCRIPTION
## Summary
- change the information table styling to size itself to its content instead of stretching across the full width

## Testing
- python3 -m http.server 8000 (for manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68db2cba97e88333a1ae95b214e57151