### PR TITLE
Ensure performance section text precedes chart on all viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,13 +86,13 @@
             <section class="py-5 bg-light" id="performance">
                 <div class="container px-5 my-5">
                     <div class="row gx-5 align-items-center">
-                        <div class="col-lg-5 mb-5 mb-lg-0">
+                        <div class="col-lg-5 mb-5 mb-lg-0 order-1 order-lg-1">
                             <h2 class="fw-bolder">Proven results</h2>
                             <p class="lead fw-normal text-muted mb-0">
                                 Our flagship Global Multifactor strategy has significantly outperformed the broad global equity market over the past five years.
                             </p>
                         </div>
-                        <div class="col-lg-7">
+                        <div class="col-lg-7 order-2 order-lg-2">
                             <div class="bg-white rounded-3 shadow-sm p-3">
                                 <canvas id="performance-chart" style="min-height: 340px"></canvas>
                             </div>


### PR DESCRIPTION
## Summary
- update the performance section column classes so the “Proven results” content remains left of the chart on large screens and first vertically on small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db33f01d188333a89af273100ad6df