### PR TITLE
Center information table and heading on information page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -10870,6 +10870,8 @@ html {
   border-collapse: collapse;
   width: auto;
   font-size: 12pt;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .information-table th,

--- a/information.html
+++ b/information.html
@@ -12,7 +12,7 @@
         <div class="container-fluid px-4 py-5">
             <div class="row justify-content-center">
                 <div class="col-12">
-                    <p class="mb-3"><b>Stewardship Partners Investment Counsel, Inc.<br>
+                    <p class="mb-3 text-center"><b>Stewardship Partners Investment Counsel, Inc.<br>
                         Global Multifactor Equity Composite<br>
                         Annual Disclosure Presentation</b></p>
                     <div class="table-responsive mb-2">


### PR DESCRIPTION
## Summary
- center the information table on the information page by giving it automatic horizontal margins
- center the heading above the information table so it aligns with the table

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db328cf61083339062e28699e8c6fc